### PR TITLE
Feature: Validate key in actions. Fix: Throws Exception `The identifi…

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,18 +29,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
-      - name: Diff files Metadata
-        id: diff-files-metadata
-        run: |
-          WORKDIR='/data'
-          GIT_DIFF="$(git diff --name-only --diff-filter=dr ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -E '(.php)$')"
-          echo $GIT_DIFF
-          for i in $(echo "${GIT_DIFF[@]}" | tr " " "\n"); do
-              FILES="${FILE} ${WORKDIR}/${i}"
-          done
-          echo $FILES
-          echo "::set-output name=files::$FILES"
-          echo "::set-output name=workdir::$WORKDIR"
       - name: Install Composer
         run: |
           docker run --rm \
@@ -53,5 +41,5 @@ jobs:
               --no-interaction
       - name: Run a PHPCS
         run: |
-          echo ${{ steps.diff-files-metadata.outputs.files }}
-          bash bin/phpcs.sh ${{ steps.diff-files-metadata.outputs.files }}
+          git diff --name-only --diff-filter=dr ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -E '(.php)$'
+          bash bin/phpcs.sh $(git diff --name-only --diff-filter=dr ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -E '(.php)$')

--- a/model/Exceptions/ActionNotFoundException.php
+++ b/model/Exceptions/ActionNotFoundException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Egal\Model\Exceptions;
+
+use Exception;
+
+class ActionNotFoundException extends Exception
+{
+
+    protected $code = 500;
+
+    public static function make(string $modelName, string $actionName): self
+    {
+        $exception = new static();
+        $exception->message = $actionName . ' not found in ' . $modelName . '!';
+
+        return $exception;
+    }
+
+}

--- a/model/Exceptions/DuplicatePrimaryKeyModelMetadataException.php
+++ b/model/Exceptions/DuplicatePrimaryKeyModelMetadataException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Egal\Model\Exceptions;
+
+use Exception;
+
+class DuplicatePrimaryKeyModelMetadataException extends Exception
+{
+
+    protected $message = 'Duplicate primary key in model metadata!';
+
+    protected $code = 500;
+
+}

--- a/model/Exceptions/FieldNotFoundException.php
+++ b/model/Exceptions/FieldNotFoundException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Egal\Model\Exceptions;
+
+use Exception;
+
+class FieldNotFoundException extends Exception
+{
+
+    protected $message = 'Field not found!';
+
+}

--- a/model/Metadata/ModelMetadata.php
+++ b/model/Metadata/ModelMetadata.php
@@ -1,68 +1,69 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Egal\Model\Metadata;
 
-use Egal\Auth\Accesses\PermissionAccess;
-use Egal\Auth\Accesses\RoleAccess;
-use Egal\Auth\Accesses\ServiceAccess;
-use Egal\Auth\Accesses\StatusAccess;
+use Egal\Model\Exceptions\ActionNotFoundException;
+use Egal\Model\Exceptions\DuplicatePrimaryKeyModelMetadataException;
+use Egal\Model\Exceptions\FieldNotFoundException;
 use Egal\Model\Exceptions\ModelMetadataException;
 use Egal\Model\Exceptions\RelationNotFoundException;
-use Exception;
 use phpDocumentor\Reflection\DocBlock;
-use phpDocumentor\Reflection\DocBlock\Tags\Generic;
-use phpDocumentor\Reflection\DocBlock\Tags\Property;
 use phpDocumentor\Reflection\DocBlockFactory;
 use ReflectionClass;
-use ReflectionException;
-use ReflectionMethod;
 
 /**
- * @package Egal\Model
+ * TODO: Получать из $this->validationRules с выборкой именно fields
  */
 class ModelMetadata
 {
 
     protected string $modelClass;
+
     protected string $modelShortName;
-    protected array $databaseFields = []; # TODO: Получать из $this->validationRules с выборкой именно fields
-    protected array $fieldsWithTypes = [];
-    protected array $fakeFields = [];
-    protected array $relations = [];
-    protected array $validationRules = [];
-    private array $primaryKeys = [];
 
     /**
-     * @var ModelActionMetadata[]
+     * @var string[]
+     * @deprecated from v2.0.0, use {@see ModelMetadata::$fields}.
+     */
+    protected array $databaseFields = [];
+
+    /**
+     * @var string[]
+     */
+    protected array $fields = [];
+
+    /**
+     * @var mixed[]
+     */
+    protected array $fieldsWithTypes = [];
+
+    /**
+     * @var string[]
+     */
+    protected array $fakeFields = [];
+
+    /**
+     * @var string[]
+     */
+    protected array $relations = [];
+
+    /**
+     * @var string[]
+     */
+    protected array $validationRules = [];
+
+    /**
+     * @var \Egal\Model\Metadata\ModelActionMetadata[]
      */
     protected array $actionsMetadata = [];
 
-    /**
-     * @return array
-     * @throws ReflectionException
-     */
-    public function toArray(): array
-    {
-        $result = [];
-        $result['model_class'] = $this->modelClass;
-        $result['model_short_name'] = $this->modelShortName;
-        $result['database_fields'] = $this->databaseFields;
-        $result['fields_with_types'] = $this->fieldsWithTypes;
-        $result['fake_fields'] = $this->fakeFields;
-        $result['relations'] = $this->relations;
-        $result['validation_rules'] = $this->validationRules;
-        $result['primary_keys'] = $this->primaryKeys;
-        foreach ($this->actionsMetadata as $key => $actionMetadata) {
-            $result['actions_metadata'][$key] = $actionMetadata->toArray();
-        }
-        return $result;
-    }
+    private ?string $primaryKey = null;
 
     /**
-     * ModelMetadata constructor.
-     * @param string $modelClass
-     * @throws ReflectionException
-     * @throws Exception
+     * @throws \ReflectionException
+     * @throws \Exception
      */
     public function __construct(string $modelClass)
     {
@@ -70,12 +71,43 @@ class ModelMetadata
         $modelReflectionClass = new ReflectionClass($this->modelClass);
         $this->modelShortName = $modelReflectionClass->getShortName();
         $docComment = $modelReflectionClass->getDocComment();
-        if ($docComment) {
-            $docBlock = DocBlockFactory::createInstance()->create($docComment);
-            $this->scanProperties($docBlock);
-            $this->scanActionsFromClassDocBlock($modelReflectionClass, $docBlock);
+
+        if (!$docComment) {
+            return;
         }
-        $this->databaseFields = array_keys($this->validationRules);
+
+        $docBlock = DocBlockFactory::createInstance()->create($docComment);
+        $this->scanProperties($docBlock);
+        $this->scanActionsFromClassDocBlock($modelReflectionClass, $docBlock);
+    }
+
+    /**
+     * TODO: Remove 'database_fields' from v2.0.0.
+     * TODO: Remove 'primary_keys' from v2.0.0.
+     *
+     * @return mixed[]
+     * @throws \ReflectionException
+     */
+    public function toArray(): array
+    {
+        $result = [
+            'model_class' => $this->modelClass,
+            'model_short_name' => $this->modelShortName,
+            'database_fields' => $this->fields,
+            'fields' => $this->fields,
+            'fields_with_types' => $this->fieldsWithTypes,
+            'fake_fields' => $this->fakeFields,
+            'relations' => $this->relations,
+            'validation_rules' => $this->validationRules,
+            'primary_keys' => $this->getPrimaryKeys(),
+            'actions_metadata' => [],
+        ];
+
+        foreach ($this->actionsMetadata as $key => $actionMetadata) {
+            $result['actions_metadata'][$key] = $actionMetadata->toArray();
+        }
+
+        return $result;
     }
 
     /**
@@ -88,10 +120,11 @@ class ModelMetadata
 
     /**
      * @return array
+     * @depricated from v2.0.0
      */
     public function getPrimaryKeys(): array
     {
-        return $this->primaryKeys;
+        return [$this->primaryKey];
     }
 
     /**
@@ -104,158 +137,75 @@ class ModelMetadata
 
     /**
      * @return array
+     * @deprecated from v2.0.0, use {@see ModelMetadata::getFields()}
      */
     public function getDatabaseFields(): array
     {
-        return $this->databaseFields;
+        return $this->fields;
     }
 
-    /**
-     * @return string
-     */
     public function getModelShortName(): string
     {
         return $this->modelShortName;
     }
 
-    /**
-     * @return string
-     */
     public function getModelClass(): string
     {
         return $this->modelClass;
     }
 
-    /**
-     * @param string $modelClass
-     */
     public function setModelClass(string $modelClass): void
     {
         $this->modelClass = $modelClass;
     }
 
-    protected function scanActions(): void
+    /**
+     * @return string[]
+     */
+    public function getFields(): array
     {
-        # TODO
+        return $this->fields;
     }
 
     /**
-     * Разбирает все property в phpDoc и отбирает field, relation и правила валидации
-     *
-     * @param DocBlock $docBlock
+     * @return mixed[]
      */
-    protected function scanProperties(DocBlock $docBlock): void
+    public function getValidationRules(?string $propertyName = null): array
     {
-        /** @var Property $property */
-        foreach ($docBlock->getTagsByName('property') as $property) {
-            $propertyTags = $property->getDescription()->getTags();
-            /** @var Generic $propertyTag */
-            foreach ($propertyTags as $propertyTag) {
-                $bodyTemplate = $propertyTag->getDescription()
-                    ? $propertyTag->getDescription()->getBodyTemplate()
-                    : '';
-                $tagName = $propertyTag->getName();
+        if ($propertyName) {
+            $this->fieldExistOrFail($propertyName);
 
-                if ($tagName === 'validation-rules') {
-                    $this->validationRules[$property->getVariableName()] = explode('|', $bodyTemplate);
-                }
-
-                if ($tagName === 'property-type' && $bodyTemplate === 'field') {
-                    $this->databaseFields[] = $property->getVariableName();
-                    $this->fieldsWithTypes[$property->getVariableName()] = $property->getType();
-                }
-
-                if ($tagName === 'property-type' && $bodyTemplate === 'relation') {
-                    $this->relations[] = $property->getVariableName();
-                }
-
-                if ($tagName === 'primary-key') {
-                    $this->primaryKeys[] = $property->getVariableName();
-                }
-            }
+            return $this->validationRules[$propertyName] ?? [];
         }
-    }
 
-    /**
-     * @param ReflectionClass $modelReflectionClass
-     * @param DocBlock $docBlock
-     * @throws Exception
-     */
-    protected function scanActionsFromClassDocBlock(ReflectionClass $modelReflectionClass, DocBlock $docBlock): void
-    {
-        /** @var Generic $tag */
-        foreach ($docBlock->getTagsByName('action') as $tag) {
-            $actionName = $tag->getDescription()->getBodyTemplate();
-            $actionName = str_replace([' ', '%', '$', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10'], '#', $actionName);
-            $actionNameExtra = stristr($actionName, '#');
-            $actionName = str_replace($actionNameExtra, '', $actionName);
-            $actionCurrentName = ModelActionMetadata::getCurrentActionName($actionName);
-            if ($modelReflectionClass->hasMethod($actionCurrentName)) {
-                $reflectionMethod = $modelReflectionClass->getMethod($actionCurrentName);
-                if (!$reflectionMethod->isStatic()) {
-                    throw new ModelMetadataException('All actions methods of the model must be static!');
-                }
-
-                $modelActionMetadata = new ModelActionMetadata();
-                $modelActionMetadata->setActionName($actionName);
-                $modelActionMetadata->setParameters($reflectionMethod->getParameters());
-                /** @var Generic $actionTag */
-                foreach ($tag->getDescription()->getTags() as $actionTag) {
-                    $modelActionMetadata->supplementFromTag($actionTag);
-                }
-                $this->addActionMetadata($modelActionMetadata);
-            }
-        }
-    }
-
-    protected function addActionMetadata(ModelActionMetadata $modelActionMetadata): void
-    {
-        if (!isset($this->actionsMetadata[$modelActionMetadata->getActionName()])) {
-            $this->actionsMetadata[$modelActionMetadata->getActionName()] = $modelActionMetadata;
-        }
-    }
-
-    /**
-     * @return array
-     */
-    public function getValidationRules(): array
-    {
         return $this->validationRules;
     }
 
     /**
-     * @param array $validationRules
+     * @param mixed[] $validationRules
      * @return $this
      */
     public function setValidationRules(array $validationRules): self
     {
         $this->validationRules = $validationRules;
+
         return $this;
     }
 
     /**
-     * @param string $propertyName
-     * @param string ...$propertyValidationRules
      * @return $this
      */
     public function addValidationRules(string $propertyName, string ...$propertyValidationRules): ModelMetadata
     {
-        if (isset($this->validationRules[$propertyName])) {
-            $this->validationRules[$propertyName] = array_merge(
-                $this->validationRules[$propertyName],
-                $propertyValidationRules
-            );
-        } else {
-            $this->validationRules[$propertyName] = $propertyValidationRules;
-        }
+        $this->validationRules[$propertyName] = isset($this->validationRules[$propertyName])
+            ? array_merge($this->validationRules[$propertyName], $propertyValidationRules)
+            : $propertyValidationRules;
 
         return $this;
     }
 
     /**
-     * @param string $actionName
-     * @return ModelActionMetadata
-     * @throws Exception
+     * @throws \Egal\Model\Exceptions\ActionNotFoundException
      */
     public function getAction(string $actionName): ModelActionMetadata
     {
@@ -263,14 +213,29 @@ class ModelMetadata
             return $this->actionsMetadata[$actionName];
         }
 
-        throw new ModelMetadataException(
-            $actionName . ' does not exist in the model ' . $this->modelClass . '!'
-        );
+        throw ActionNotFoundException::make($this->modelClass, $actionName);
     }
 
+    /**
+     * @deprecated from 2.0.0, use {@see ModelMetadata::fieldExist()}
+     */
     public function databaseFieldExists(string $string): bool
     {
-        return in_array($string, $this->databaseFields);
+        return $this->fieldExist($string);
+    }
+
+    public function fieldExist(string $fieldName): bool
+    {
+        return in_array($fieldName, $this->fields);
+    }
+
+    public function fieldExistOrFail(string $fieldName): bool
+    {
+        if (!$this->fieldExist($fieldName)) {
+            throw new FieldNotFoundException();
+        }
+
+        return true;
     }
 
     public function relationExist(string $relation): bool
@@ -278,6 +243,9 @@ class ModelMetadata
         return in_array($relation, $this->relations);
     }
 
+    /**
+     * @throws \Egal\Model\Exceptions\RelationNotFoundException
+     */
     public function relationExistOrFail(string $relation): bool
     {
         if (!$this->relationExist($relation)) {
@@ -285,6 +253,110 @@ class ModelMetadata
         }
 
         return true;
+    }
+
+    public function getPrimaryKey(): ?string
+    {
+        return $this->primaryKey;
+    }
+
+    protected function scanActions(): void
+    {
+        // TODO: Implement functionality!
+    }
+
+    /**
+     * Разбирает все property в phpDoc и отбирает field, relation и правила валидации
+     *
+     * @throws \Egal\Model\Exceptions\DuplicatePrimaryKeyModelMetadataException
+     */
+    protected function scanProperties(DocBlock $docBlock): void
+    {
+        /** @var \phpDocumentor\Reflection\DocBlock\Tags\Property $property */
+        foreach ($docBlock->getTagsByName('property') as $property) {
+            $propertyTags = $property->getDescription()->getTags();
+            /** @var \phpDocumentor\Reflection\DocBlock\Tags\Generic $propertyTag */
+            foreach ($propertyTags as $propertyTag) {
+                $bodyTemplate = $propertyTag->getDescription()
+                    ? $propertyTag->getDescription()->getBodyTemplate()
+                    : '';
+                $tagName = $propertyTag->getName();
+
+                switch ($tagName) {
+                    case 'validation-rules':
+                        $this->validationRules[$property->getVariableName()] = explode('|', $bodyTemplate);
+                        break;
+                    case 'primary-key':
+                        if (isset($this->primaryKey)) {
+                            throw new DuplicatePrimaryKeyModelMetadataException();
+                        }
+
+                        if ($property->getVariableName()) {
+                            $this->primaryKey = (string) $property->getVariableName();
+                        }
+
+                        break;
+                    case 'property-type':
+                        if ($bodyTemplate === 'field') {
+                            $this->fields[] = $property->getVariableName();
+                            $this->fieldsWithTypes[$property->getVariableName()] = $property->getType();
+                        } elseif ($bodyTemplate === 'relation') {
+                            $this->relations[] = $property->getVariableName();
+                        }
+
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+    }
+
+    /**
+     * @throws \Egal\Model\Exceptions\ModelActionMetadataException|\Egal\Model\Exceptions\ModelMetadataException
+     */
+    protected function scanActionsFromClassDocBlock(ReflectionClass $modelReflectionClass, DocBlock $docBlock): void
+    {
+        /** @var \phpDocumentor\Reflection\DocBlock\Tags\Generic $tag */
+        foreach ($docBlock->getTagsByName('action') as $tag) {
+            $actionName = $tag->getDescription()->getBodyTemplate();
+            $actionName = str_replace(
+                [' ', '%', '$', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10'],
+                '#',
+                $actionName
+            );
+            $actionNameExtra = stristr($actionName, '#');
+            $actionName = str_replace($actionNameExtra, '', $actionName);
+            $actionCurrentName = ModelActionMetadata::getCurrentActionName($actionName);
+
+            if (!$modelReflectionClass->hasMethod($actionCurrentName)) {
+                continue;
+            }
+
+            $reflectionMethod = $modelReflectionClass->getMethod($actionCurrentName);
+
+            if (!$reflectionMethod->isStatic()) {
+                throw new ModelMetadataException('All actions methods of the model must be static!');
+            }
+
+            $modelActionMetadata = new ModelActionMetadata();
+            $modelActionMetadata->setActionName($actionName);
+            $modelActionMetadata->setParameters($reflectionMethod->getParameters());
+            /** @var \phpDocumentor\Reflection\DocBlock\Tags\Generic $actionTag */
+            foreach ($tag->getDescription()->getTags() as $actionTag) {
+                $modelActionMetadata->supplementFromTag($actionTag);
+            }
+            $this->addActionMetadata($modelActionMetadata);
+        }
+    }
+
+    protected function addActionMetadata(ModelActionMetadata $modelActionMetadata): void
+    {
+        if (isset($this->actionsMetadata[$modelActionMetadata->getActionName()])) {
+            return;
+        }
+
+        $this->actionsMetadata[$modelActionMetadata->getActionName()] = $modelActionMetadata;
     }
 
 }

--- a/model/Traits/UsesValidator.php
+++ b/model/Traits/UsesValidator.php
@@ -1,49 +1,72 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Egal\Model\Traits;
 
 use Egal\Model\Exceptions\ValidateException;
 use Egal\Model\Model;
 use Illuminate\Support\Facades\Validator;
-use ReflectionException;
 
-/**
- * Trait UsesValidator
- * @package Egal\Model
- */
 trait UsesValidator
 {
 
     /**
-     * @throws ValidateException
-     * @throws ReflectionException
-     * @noinspection PhpUnused
+     * @throws \Egal\Model\Exceptions\ValidateException
+     * @throws \ReflectionException
      */
-    protected static function bootUsesValidator()
+    protected static function bootUsesValidator(): void
     {
-        static::saving(function ($entity) {
-            /** @var Model $entity */
-            // Получаем все измененные атрибуты
-            $attributes = $entity->getDirty();
-
+        static::saving(static function (Model $entity): void {
             // Получаем validation rules
             // всех атрибутов если объект новый,
             // только измененных атрибутов если объект обновляется.
             //
             // Получение validation rules только измененных атрибутов происходит
-            // путем получения пересечения всех validation rules и измененный атрибутов по ключам
+            // путем получения пересечения всех validation rules и измененный атрибутов по ключам.
             $validationRules = $entity->exists
-                ? array_intersect_key($entity->getValidationRules(), $attributes)
+                ? array_intersect_key($entity->getValidationRules(), $entity->getDirty())
                 : $entity->getValidationRules();
 
-            // Применяем полученные validation rules на все атрибуты модели
+            // Применяем полученные validation rules на все атрибуты модели.
             $validator = Validator::make($entity->getAttributes(), $validationRules);
+
             if ($validator->fails()) {
                 $exception = new ValidateException();
                 $exception->setMessageBag($validator->errors());
+
                 throw $exception;
             }
         });
+    }
+
+    /**
+     * @param mixed $keyValue
+     * @throws \Egal\Model\Exceptions\ValidateException
+     */
+    private function validateKey($keyValue): void
+    {
+        $primaryKey = $this->getModelMetadata()->getPrimaryKey();
+
+        if ($primaryKey === null) {
+            $validator = Validator::make(
+                [$this->getKeyName() => $keyValue],
+                [$this->getKeyName() => [$this->getKeyType()]]
+            );
+        } else {
+            $validationRules = $this->getModelMetadata()->getValidationRules($primaryKey);
+            $validator = Validator::make(
+                [$primaryKey => $keyValue],
+                [$primaryKey => $validationRules === [] ? [$this->getKeyType()] : $validationRules]
+            );
+        }
+
+        if ($validator->fails()) {
+            $exception = new ValidateException();
+            $exception->setMessageBag($validator->errors());
+
+            throw $exception;
+        }
     }
 
 }

--- a/tests/Model/ModelMetadataTest.php
+++ b/tests/Model/ModelMetadataTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Egal\Tests\Model;
+
+use Egal\Model\Metadata\ModelMetadata;
+use Egal\Model\Model;
+use PHPUnit\Framework\TestCase;
+
+class ModelMetadataTest extends TestCase
+{
+
+    public function testGetValidationRules()
+    {
+        $this->assertEquals(
+            [
+                'id' => ['integer'],
+                'foo' => ['string', 'max:10']
+            ],
+            (new ModelMetadata(ModelMetadataTestModelWithValidationRulesStub::class))
+                ->getValidationRules()
+        );
+    }
+
+    public function testGetValidationRulesOfField()
+    {
+        $this->assertEquals(
+            ['integer'],
+            (new ModelMetadata(ModelMetadataTestModelWithValidationRulesStub::class))
+                ->getValidationRules('id')
+        );
+        $this->assertEquals(
+            ['string', 'max:10'],
+            (new ModelMetadata(ModelMetadataTestModelWithValidationRulesStub::class))
+                ->getValidationRules('foo')
+        );
+    }
+
+}
+
+/**
+ * @property $id  {@property-type field} {@validation-rules integer}
+ * @property $foo {@property-type field} {@validation-rules string|max:10}
+ */
+class ModelMetadataTestModelWithValidationRulesStub extends Model
+{
+
+}

--- a/tests/Model/ModelUsesValidatorTest.php
+++ b/tests/Model/ModelUsesValidatorTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Egal\Tests\Model;
+
+use Egal\Model\Exceptions\ValidateException;
+use Egal\Model\Metadata\ModelMetadata;
+use Egal\Model\Model;
+use Egal\Tests\PHPUnitUtil;
+use Laravel\Lumen\Application;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class ModelUsesValidatorTest extends TestCase
+{
+
+    public function testValidateKeyDataProvider()
+    {
+        return [
+            [['integer'], 1, false],
+            [['integer'], 'foo', true],
+            [['string'], 1, true],
+            [['string'], 'foo', false],
+            [['string', 'required'], 'foo', false],
+        ];
+    }
+
+    /**
+     * @dataProvider testValidateKeyDataProvider()
+     */
+    public function testValidateKey(array $validationRules, $keyValue, bool $expectValidateException)
+    {
+        $app = new Application(dirname(__DIR__));
+        $app->withFacades();
+
+        $keyName = 'foo';
+
+        $metadata = m::mock(
+            ModelMetadata::class . '[getPrimaryKey,fieldExist,getValidationRules]',
+            [Model::class]
+        );
+        $metadata->shouldReceive('getPrimaryKey')->andReturn($keyName);
+        $metadata->shouldReceive('fieldExist')->with($keyName)->andReturn(true);
+        $metadata->shouldReceive('getValidationRules')->with($keyName)->andReturn($validationRules);
+
+        $model = m::mock(Model::class . '[getModelMetadata]');
+        $model->shouldReceive('getModelMetadata')->andReturn($metadata);
+
+        if ($expectValidateException) {
+            $this->expectException(ValidateException::class);
+        }
+
+        PHPUnitUtil::callMethod($model, 'validateKey', $keyValue);
+    }
+
+}


### PR DESCRIPTION
…er of the entity being updated is not specified!` when sends `$id` param. (#84)

* Update: Code style fix.

* Update: Validate key in actions.

* Fix: Throws Exception 'The identifier of the entity being updated is not specified!' when sends `$id` param.

* Update: Replace ModelMetadata::$primaryKeys => ModelMetadata::$primaryKey.

* Update: Dynamic Model key validation without metadata.

* Update: Disable configure fields from validation rules in ModelMetadata.

* Update: Add validation rules for key if primary key declared in metadata, but not declared validation rules for him.