### PR TITLE
Fix: Throws exception when sends multiple nested array to FilterPart::fromArray().

### DIFF
--- a/model/Exceptions/InitializeFilterPartException.php
+++ b/model/Exceptions/InitializeFilterPartException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Egal\Model\Exceptions;
+
+use Exception;
+
+class InitializeFilterPartException extends Exception
+{
+
+    protected $message = 'Failed initialize filter part!';
+
+    protected $code = 403;
+
+}

--- a/model/Filter/FilterPart.php
+++ b/model/Filter/FilterPart.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Egal\Model\Filter;
 
 use Egal\Model\Exceptions\FilterException;
+use Egal\Model\Exceptions\InitializeFilterPartException;
 
 final class FilterPart
 {
@@ -16,7 +17,7 @@ final class FilterPart
 
     /**
      * @param mixed[] $array
-     * @throws \Egal\Model\Exceptions\FilterException
+     * @throws \Egal\Model\Exceptions\FilterException|\Egal\Model\Exceptions\InitializeFilterPartException
      */
     public static function fromArray(array $array): FilterPart
     {
@@ -25,10 +26,12 @@ final class FilterPart
         foreach ($array as $item) {
             if (FilterCondition::mayMakeFromArray($item)) {
                 $filterPart->addContentItem(FilterCondition::fromArray($item));
-            } elseif (FilterCombiner::mayMakeFromString($item)) {
-                $filterPart->addContentItem(FilterCombiner::fromString($item));
             } elseif (is_array($item)) {
                 $filterPart->addContentItem(self::fromArray($item));
+            } elseif (FilterCombiner::mayMakeFromString($item)) {
+                $filterPart->addContentItem(FilterCombiner::fromString($item));
+            } else {
+                throw new InitializeFilterPartException();
             }
         }
 

--- a/tests/Model/ModelFilterFilterPartTest.php
+++ b/tests/Model/ModelFilterFilterPartTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Egal\Tests\Model;
+
+use Egal\Model\Filter\FilterPart;
+use PHPUnit\Framework\TestCase;
+
+class ModelFilterFilterPartTest extends TestCase
+{
+
+    public function simpleDataProvider()
+    {
+        return [
+            [
+                [["foo", "eq", "bar"]],
+                null
+            ],
+            [
+                [[
+                    ["foo", "eq", "bar"],
+                    "and",
+                    ["foo", "eq", "bar"],
+                ]],
+                null
+            ],
+            [
+                [[
+                    ["foo", "eq", "bar"],
+                    "and",
+                    [[[[[[["foo", "eq", "bar"]]]]]]],
+                ]],
+                null
+            ],
+            [
+                [[[[[["foo", "eq", "bar"]]]]]],
+                null
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider simpleDataProvider()
+     */
+    public function testSimple(array $array, ?string $expectException)
+    {
+        if ($expectException) {
+            $this->expectException($expectException);
+        }
+
+        $result = FilterPart::fromArray($array);
+
+        if (!$expectException) {
+            $this->assertNotNull($result);
+        }
+    }
+
+}


### PR DESCRIPTION
Ошибка, которая была исправлена:
```json
"action_error": {
    "type": "action_error",
    "code": 0,
    "message": "Argument 1 passed to Egal\\Model\\Filter\\FilterCombiner::mayMakeFromString() must be of the type string, array given, called in \/app\/vendor\/egal\/framework\/model\/Filter\/FilterPart.php on line 28",
    "uuid": "a4939306-71aa-4c4e-9696-b1c0af0ffc52",
    "action_message": {
      "type": "action",
      "service_name": ***,
      "model_name": ***,
      "action_name": "getItems",
      "parameters": {
        "withs": [],
        "filter": [
          [
            [
              ***,
              "eq",
              "3bc62f10-e6bf-40bc-b7be-0598b1f5da45"
            ],
            "and",
            [
              ***,
              "eq",
              "4ad40ad8-cbd0-3ab3-9e1b-a8ddcf6025ce"
            ]
          ]
        ],
        "pagination": null,
        "id": ""
      },
      "token": ***,
      "uuid": "cb93c3c0-3dab-4ffe-9b92-b18c4c080d1d"
    }
  },