### PR TITLE
Fix: Typo `CenrifugoBroadcastable` (need `CentrifugoBroadcastable`).

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -224,7 +224,7 @@
         <exclude-pattern>src/Centrifugo/CentrifugoBroadcaster.php</exclude-pattern>
     </rule>
     <rule ref="SlevomatCodingStandard.Classes.ForbiddenPublicProperty.ForbiddenPublicProperty">
-        <exclude-pattern>src/Centrifugo/CenrifugoBroadcastable.php</exclude-pattern>
+        <exclude-pattern>src/Centrifugo/CentrifugoBroadcastable.php</exclude-pattern>
     </rule>
 
     <exclude-pattern type="relative-root">*/tests/*</exclude-pattern>

--- a/src/Centrifugo/CentrifugoBroadcastable.php
+++ b/src/Centrifugo/CentrifugoBroadcastable.php
@@ -6,7 +6,7 @@ namespace Egal\Centrifugo;
 
 use Egal\Model\Model;
 
-trait CenrifugoBroadcastable
+trait CentrifugoBroadcastable
 {
 
     public string $connection = 'sync';

--- a/src/Centrifugo/CentrifugoEvent.php
+++ b/src/Centrifugo/CentrifugoEvent.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Event;
 abstract class CentrifugoEvent extends Event implements ShouldBroadcast
 {
 
-    use CenrifugoBroadcastable;
+    use CentrifugoBroadcastable;
 
     protected Model $entity;
 


### PR DESCRIPTION
Corrected a typo in a word "Centrifugo"